### PR TITLE
Update default tools version in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
   parameters {
     string(
       name: 'TOOLS_VERSION',
-      defaultValue: '15.0.5',
+      defaultValue: '15.1.4',
       description: 'The tools version to build with (check /projects/tools/ReleasesTools/)'
     )
   }


### PR DESCRIPTION
Using Tools 15.0.5 by default can cause problems with our hardware agents as firmware updates to newer versions run by other jobs require a power cycle; updating to Tools 15.1.4 avoids this issue.