### PR TITLE
Feature/warn checks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,8 +36,10 @@ pipeline {
         stage('Static analysis') {
           steps {
             withVenv() {
-              sh "flake8 --exit-zero --output-file=flake8.xml xscope_fileio"
-              recordIssues enabledForFailure: true, tool: flake8(pattern: 'flake8.xml')
+              warnError("Flake") {
+                sh "flake8 --exit-zero --output-file=flake8.xml xscope_fileio"
+                recordIssues enabledForFailure: true, tool: flake8(pattern: 'flake8.xml')
+              }
             }
           }
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ pylint==2.5.3
 pytest==6.0.0
 pytest-xdist==1.34.0
 
+# Pin importlib-metadata to <5 due to https://github.com/python/importlib_metadata/issues/409.
+importlib-metadata==4.13.0
+
 # self-install
 -e ./
 -e xtagctl/


### PR DESCRIPTION
This matches behaviour in `xcoreLibraryChecks`.
Currently, an issue with an update to a flake8 dependency is causing jobs like this to be red and untested.
This will cause them to go yellow and continue testing further than flake8.