### PR TITLE
Use xcoreCleanSandbox instead of cleanWs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('xmos_jenkins_shared_library@v0.19.0') _
+@Library('xmos_jenkins_shared_library@v0.20.0') _
 
 getApproval()
 
@@ -115,7 +115,7 @@ pipeline {
           archiveArtifacts artifacts: "**/*.bin", fingerprint: true, allowEmptyArchive: true
         }
         cleanup {
-          cleanWs()
+          xcoreCleanSandbox()
         }
       }
     }
@@ -137,7 +137,7 @@ pipeline {
       }
       post {
         cleanup {
-          cleanWs()
+          xcoreCleanSandbox()
         }
       }
     }


### PR DESCRIPTION
also bump xjsl to 0.20
This should stop issues cleaning up the windows build like these: http://srv-bri-jcim0:8080/administrativeMonitor/AsyncResourceDisposer/