### PR TITLE
Manual xmake to build xc example in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,9 @@ pipeline {
             withTools(params.TOOLS_VERSION) {
               sh 'tree'
               sh 'cd examples/throughput_c && make'
-              sh 'cd examples/fileio_features_xc && xmake'
+              withEnv(["XMOS_MODULE_PATH=${WORKSPACE}", "XCOMMON_DISABLE_AUTO_MODULE_SEARCH=1"]) {
+                sh 'cd examples/fileio_features_xc && xmake'
+              }
             }
           }
         }


### PR DESCRIPTION
xmake automatically searches up too many levels if the parent dir is a repo, expecting a sandbox.
For this repo, there is no sandbox so it was looking outside the jenkins workspace and getting confused with other branches.

Example of issue: http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Fxscope_fileio/detail/develop/195/pipeline
`xmake[1]: *** /jenkins/workspace/XMOS_lib_audio_pipelines_master/xscope_fileio: Is a directory.  Stop.`

xcommon docs explanation: https://www.xmos.ai/documentation/XM-014363-PC-4/html/tools-guide/tools-ref/xcommon/using-makefiles.html#workspace-structure-and-automatic-module-detection
`If the folder above the application is detected as a repository but the folder above that is then the Makefiles will search at that level.` (poorly worded but the example looks similar to what is happening in this repo)

Builds 198-204 are reruns of xcsope_fileio with this change in place. Build 202 failed as an experiment to see what happened if we didn't set the XMOS_MODULE_PATH variable.