### PR TITLE
Add build discarding

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,10 @@ pipeline {
   }
   options {
     skipDefaultCheckout()
+    buildDiscarder(logRotator(
+        numToKeepStr:         env.BRANCH_NAME ==~ /develop/ ? '50' : '',
+        artifactNumToKeepStr: env.BRANCH_NAME ==~ /develop/ ? '50' : ''
+    ))
   }
   stages {
     stage('xcore.ai') {


### PR DESCRIPTION
Jenkins currently has 52GB of develop builds sitting around. This should allow us to stop that from growing forever.