### PR TITLE
Archive artifact of release build of Windows host endpoint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,8 +131,8 @@ pipeline {
         withTools(params.TOOLS_VERSION) {
           dir('host') {
             withVS("vcvars32.bat") {
-              sh 'cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release .'
-              sh 'nmake'
+              sh 'cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release .'
+              sh 'ninja'
             }
 
             archiveArtifacts artifacts: "xscope_host_endpoint.exe", fingerprint: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,7 +131,7 @@ pipeline {
         withTools(params.TOOLS_VERSION) {
           dir('host') {
             withVS("vcvars32.bat") {
-              sh 'cmake -G"NMake Makefiles" .'
+              sh 'cmake -G"NMake Makefiles" -DCMAKE_BUILD_TYPE=Release .'
               sh 'nmake'
             }
 


### PR DESCRIPTION
Set the `CMAKE_BUILD_TYPE` so that a release build is created to avoid the need for debug libraries to be present on the Windows host when this application is run.