### PR TITLE
Feature/xscope fclose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+bin/
 develop-eggs/
 dist/
 downloads/
@@ -112,6 +113,8 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.vscode
+.venv*
 
 # Spyder project settings
 .spyderproject
@@ -161,3 +164,6 @@ build.ninja
 *.exe
 *.ilk
 *.pdb
+
+# tmp files
+*.out

--- a/examples/fileio_feature_close/CMakeLists.txt
+++ b/examples/fileio_feature_close/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.21)
+include($ENV{XMOS_CMAKE_PATH}/xcommon.cmake)
+project(xscope_fileio_close)
+
+# sandbox
+set(XMOS_SANDBOX_DIR ../../../)
+
+# target
+set(APP_HW_TARGET XCORE-AI-EXPLORER)
+set(APP_INCLUDES src)
+
+# flags
+set(APP_COMPILER_FLAGS
+  -Os
+  -g
+  -report
+  -Wall
+  -fxscope
+  -Wno-xcore-fptrgroup
+)
+set(APP_XSCOPE_SRCS config.xscope)
+set(APP_DEPENDENT_MODULES  xscope_fileio)
+XMOS_REGISTER_APP()

--- a/examples/fileio_feature_close/README.rst
+++ b/examples/fileio_feature_close/README.rst
@@ -1,0 +1,34 @@
+example: fileio_feature_close
+=============================
+
+This example show how to use open and close files with xscope_fileio. 
+ 
+Build example
+-------------
+Run the following command from the current directory: 
+
+.. code-block:: console
+
+  cmake -G "Unix Makefiles" -B build
+  xmake -C build
+
+
+Running example
+---------------
+
+.. warning::
+
+  Make sure ``xscope_fileio`` is installed.
+  Also make sure the adapter id is set up correctly in ``run_example.py``.
+
+Run the following command from the current directory:
+
+.. code-block:: console
+
+  python run_example.py
+
+
+Output
+------
+
+The output will be several files in the current directory inside the output folder. 

--- a/examples/fileio_feature_close/config.xscope
+++ b/examples/fileio_feature_close/config.xscope
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- ======================================================= -->
+<!-- The 'ioMode' attribute on the xSCOPEconfig              -->
+<!-- element can take the following values:                  -->
+<!--   "none", "basic", "timed"                              -->
+<!--                                                         -->
+<!-- The 'type' attribute on Probe                           -->
+<!-- elements can take the following values:                 -->
+<!--   "STARTSTOP", "CONTINUOUS", "DISCRETE", "STATEMACHINE" -->
+<!--                                                         -->
+<!-- The 'datatype' attribute on Probe                       -->
+<!-- elements can take the following values:                 -->
+<!--   "NONE", "UINT", "INT", "FLOAT"                        -->
+<!-- ======================================================= -->
+
+<xSCOPEconfig ioMode="basic" enabled="true">
+    <Probe name="open_file" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
+    <Probe name="read_bytes" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
+    <Probe name="write_setup" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
+    <Probe name="write_bytes" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
+    <Probe name="seek" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
+    <Probe name="tell" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
+    <Probe name="host_quit" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
+    <Probe name="host_close" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
+</xSCOPEconfig>

--- a/examples/fileio_feature_close/run_example.py
+++ b/examples/fileio_feature_close/run_example.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import xscope_fileio
+import shutil
+
+firmware_xe = (Path(__file__).parent / "bin" / "xscope_fileio_close.xe").absolute()
+output_folder = (Path(__file__).parent / "output").absolute()
+
+# renew the folder
+shutil.rmtree(output_folder, ignore_errors=True)
+output_folder.mkdir(parents=False, exist_ok=True)
+
+# run the program
+# enter your xtag id here. Use xrun -l to find out what it is
+adapter_id = "EHV92U6D"
+
+print("Adapter ID: ", adapter_id)
+print("Firmware: ", firmware_xe)
+print("Output folder: ", output_folder)
+
+xscope_fileio.run_on_target(adapter_id, firmware_xe, use_xsim=False)

--- a/examples/fileio_feature_close/src/main.xc
+++ b/examples/fileio_feature_close/src/main.xc
@@ -1,0 +1,19 @@
+#include <platform.h>
+#include <xs1.h>
+#include <xscope.h>
+
+extern "C" {
+void main_tile0(chanend);
+}
+
+int main (void)
+{
+  chan xscope_chan;
+  par
+  {
+    xscope_host_data(xscope_chan);
+    on tile[0]: main_tile0(xscope_chan);
+  }
+  return 0;
+}
+

--- a/examples/fileio_feature_close/src/test.c
+++ b/examples/fileio_feature_close/src/test.c
@@ -1,0 +1,64 @@
+#include <platform.h>
+#include <stdio.h>
+#include <string.h>
+#include <xscope.h>
+#include <xcore/assert.h>
+#include <xcore/hwtimer.h>
+#include "xscope_io_device.h"
+
+
+// This test will open and close some files in different order.
+// then it will reclose all files.
+static
+void do_test1(chanend_t xscope_chan)
+{
+    xscope_file_t fp[5];
+
+    // open and close some files
+    fp[0] = xscope_open_file("output/fp0.out", "wb");
+    fp[1] = xscope_open_file("output/fp1.out", "wb");
+    fp[2] = xscope_open_file("output/fp2.out", "wb");
+    xscope_fclose(&fp[0]);
+    fp[3] = xscope_open_file("output/fp3.out", "wb");
+    xscope_fclose(&fp[2]);
+    fp[4] = xscope_open_file("output/fp4.out", "wb");    
+    xscope_fclose(&fp[1]);
+
+    // close all files
+    for (int i = 0; i < 5; i++) {
+        xscope_fclose(&fp[i]);
+    }
+}
+
+
+// This test will create a large number of files and write some data to them.
+// It will reuse the same file pointer.
+static
+void do_test2(chanend_t xscope_chan){
+    
+    const unsigned N_FILES = 240;       // number of files that will be created
+    const unsigned BUFF_SIZE = 1024;    // size of data buffer to write to each file
+
+    uint8_t data[BUFF_SIZE] = {0};
+
+    for (unsigned file_n = 0; file_n < N_FILES; file_n++){
+        char filename[24];
+        snprintf(filename, 24, "output/file_%d.out", file_n);
+        printf("%s\n", filename);
+
+        xscope_file_t fp = xscope_open_file(filename, "wb");
+        data[0] = file_n; // first index of data is the file number
+        xscope_fwrite(&fp, data, BUFF_SIZE);
+        xscope_fclose(&fp);
+    }
+
+}
+
+
+void main_tile0(chanend_t xscope_chan)
+{
+    xscope_io_init(xscope_chan);
+    do_test1(xscope_chan);
+    do_test2(xscope_chan);
+    xscope_close_all_files();
+}

--- a/host/xscope_io_host.c
+++ b/host/xscope_io_host.c
@@ -225,6 +225,20 @@ void xscope_record(
             return;
         }
         break;
+                
+        case XSCOPE_ID_HOST_CLOSE:
+        {
+            assert(length == 1 && "length shall be equal to 1");
+            unsigned file_idx = databytes[0] - '0';
+            if(VERBOSE) printf("[HOST] closing file idx: %u\n", file_idx);
+            if(host_files[file_idx].fp != NULL)
+            {
+                fclose(host_files[file_idx].fp);
+                host_files[file_idx].fp = NULL;
+            }
+        }
+        break;
+        
 
         default:
         {
@@ -274,4 +288,3 @@ int main(int argc, char *argv[])
 
     return(0);
 }
-

--- a/xscope_fileio/api/xscope_io_device.h
+++ b/xscope_fileio/api/xscope_io_device.h
@@ -117,6 +117,18 @@ int xscope_ftell(xscope_file_t *xscope_file);
  ******************************************************************************/
 void xscope_close_all_files(void);
 
+
+/******************************************************************************
+ * xscope_fclose
+ *
+ * Closes a single file on the host.
+ * It can be called at any time to close a file.
+ *
+ * @param   handle of file to operate on
+ * @return  void
+ ******************************************************************************/
+void xscope_fclose(xscope_file_t *xscope_file);
+
 #ifdef __XC__
 }
 #endif

--- a/xscope_fileio/config.xscope.txt
+++ b/xscope_fileio/config.xscope.txt
@@ -6,5 +6,5 @@
   <Probe name="seek" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
   <Probe name="tell" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
   <Probe name="host_quit" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
+  <Probe name="host_close" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/>
 </xSCOPEconfig>
-

--- a/xscope_fileio/src/xscope_io_device.c
+++ b/xscope_fileio/src/xscope_io_device.c
@@ -14,7 +14,7 @@
 
 //Global chanend so we don't need to keep passing it in for read operations
 chanend_t c_xscope = 0;
-unsigned file_idx = 0;
+uint8_t available_files[MAX_FILES_OPEN] = {0}; // 0 = available, 1 = in use
 lock_t file_access_lock;
 volatile unsigned xscope_io_init_flag = 0;
 
@@ -33,6 +33,22 @@ __attribute__((weak))
 void xscope_fileio_lock_release(void) {
     lock_release(file_access_lock);
 }
+
+
+static int get_available_file_idx(){
+    for (unsigned idx = 0; idx < MAX_FILES_OPEN; idx++){
+        if (available_files[idx] == 0){
+            available_files[idx] = 1;
+            if(VERBOSE){printf("Allocated file index: %u\n", idx);}
+            return idx;
+        }
+    }
+    return -1;
+}
+static inline void reset_available_file_idx(unsigned idx){
+    available_files[idx] = 0;
+}
+
 
 unsigned xscope_fileio_is_initialized(void) {
     return xscope_io_init_flag;
@@ -57,7 +73,7 @@ xscope_file_t xscope_open_file(const char* filename, char* attributes){
     char packet[1 + MAX_FILENAME_LEN + 1];
     unsigned length = 1 + 1 + strlen(xscope_file.filename) + 1;
     xassert(length <= 1 + 1 + MAX_FILENAME_LEN + 1);
-    packet[0] = '0' + file_idx;
+    
     if(!strcmp(attributes, "rb")){
         xscope_file.mode = XSCOPE_IO_READ_BINARY;
     }
@@ -73,18 +89,15 @@ xscope_file_t xscope_open_file(const char* filename, char* attributes){
     else{
         printf("Unknown file attribytes: %s. Please specify from: rb, rt, wb, wt\n", attributes);
     }
+    unsigned file_idx = get_available_file_idx();
+    xassert(file_idx != -1 && "Maximum number of files open exceeded");
+    packet[0] = '0' + file_idx;
     packet[1] = '0' + xscope_file.mode;
     strcpy(&packet[2], xscope_file.filename);
     xscope_file.index = file_idx;
     xscope_bytes(XSCOPE_ID_OPEN_FILE, length, (const unsigned char *)packet);
-    file_idx++;
     xscope_fileio_lock_release();
-    if(file_idx == MAX_FILES_OPEN){
-        printf("Maximum number of files open exceeded (%u)", MAX_FILES_OPEN);
-    }
-
-    //Pass a copy of the struct back to the caller
-    return xscope_file;
+    return xscope_file; //Pass a copy of the struct back to the caller
 }
 
 size_t xscope_fread(xscope_file_t *xscope_file, uint8_t *buffer, size_t n_bytes_to_read){
@@ -194,4 +207,15 @@ void xscope_close_all_files(void){
     xscope_bytes(XSCOPE_ID_HOST_QUIT, 1, (unsigned char*)"!");
     if(VERBOSE) printf("Sent close files\n");
     hwtimer_t t = hwtimer_alloc(); hwtimer_delay(t, 5000000); //50ms to allow messages to make it before xgdb quit
+}
+
+void xscope_fclose(xscope_file_t *xscope_file){
+    xscope_fileio_lock_acquire();
+    const unsigned char idx = xscope_file->index + '0';
+    xscope_bytes(XSCOPE_ID_HOST_CLOSE, 1, &idx);
+    if(VERBOSE) {
+        printf("Sent close file id: %d\n", xscope_file->index);
+    }
+    reset_available_file_idx(xscope_file->index);
+    xscope_fileio_lock_release();
 }

--- a/xscope_fileio/xscope_io_common.h
+++ b/xscope_fileio/xscope_io_common.h
@@ -23,6 +23,7 @@ enum{
     XSCOPE_ID_SEEK          = 4,
     XSCOPE_ID_TELL          = 5,
     XSCOPE_ID_HOST_QUIT     = 6, 
+    XSCOPE_ID_HOST_CLOSE    = 7,   
 };
 
 #endif


### PR DESCRIPTION
Closing: [AP-332](https://xmosjira.atlassian.net/browse/AP-322)

Changes:
- adding xscope_fclose function
- adding an example closing files using xcommon_cmake
- adding probe: host_close to config.xscope.txt

What could be included next:
- Convert the rest of the examples to xcommon_cmake.
- Add to the examples the function that gets the adapter-id instead of setting it manually.
- Add the flcose example to jenkins (xcommon_cmake)
- Build for windows (?)

[AP-332]: https://xmosjira.atlassian.net/browse/AP-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ