### PR TITLE
Release/v1.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,15 +4,16 @@ xscope fileio change log
 1.2.0
 -----
 
+  * CHANGED: Update tools version in Jenkinsfile to 15.2.1.
   * ADDED: XCommon CMake for tests and example integration.
   * FIXED: Adapter ID can now be passed to examples.
   * CHANGED: Improved documentation formatting and updates.
   * ADDED: Pytest support.
   * ADDED: xscope_fclose function for closing a single file.
-  * ADDED: Support for XCommon CMake build system
-  * FIXED: Hang in run_on_target when invalid file was opened for reading
-  * FIXED: fread no longer can cause buffer overflow
-  * FIXED: fread always returns the end of the file if eof is reached
+  * ADDED: Support for XCommon CMake build system.
+  * FIXED: Hang in run_on_target when invalid file was opened for reading.
+  * FIXED: fread no longer can cause buffer overflow.
+  * FIXED: fread always returns the end of the file if eof is reached.
 
 1.1.2
 -----


### PR DESCRIPTION
This is a release PR to version 1.2.0. 

1.2.0
-----

  * CHANGED: Update tools version in Jenkinsfile to 15.2.1.
  * ADDED: XCommon CMake for tests and example integration.
  * FIXED: Adapter ID can now be passed to examples.
  * CHANGED: Improved documentation formatting and updates.
  * ADDED: Pytest support.
  * ADDED: xscope_fclose function for closing a single file.
  * ADDED: Support for XCommon CMake build system.
  * FIXED: Hang in run_on_target when invalid file was opened for reading.
  * FIXED: fread no longer can cause buffer overflow.
  * FIXED: fread always returns the end of the file if eof is reached.